### PR TITLE
update providerPriority to prefer hardhat as over web3modal

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -24,7 +24,7 @@ task("accounts", "Prints the list of accounts", async (args, hre) => {
  */
 const config: HardhatUserConfig = {
   react: {
-    providerPriority: ["web3modal", "hardhat"],
+    providerPriority: ["hardhat", "web3modal"],
   },
   networks: {
     hardhat: {


### PR DESCRIPTION
With the current providerPriority inside of hardhat.config.ts: ```providerPriority: ["web3modal", "hardhat"],```  the app crashes when connecting to web3 using metamask b.c the greeter contract has not been deployed. The error wasn't exactly clear on what was going wrong.

<img width="1305" alt="Screen Shot 2021-09-26 at 5 12 16 PM" src="https://user-images.githubusercontent.com/15853188/134829137-67956416-a117-4999-99e8-bd9e4cb63f2f.png">


I'm suggesting to default the providerPriority as so: `providerPriority: ["hardhat", "web3modal"],` so that the app successfully runs and is defaulting to the hardhat testnet.
